### PR TITLE
Add buffering mechanism for stimulus information ...

### DIFF
--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -497,6 +497,13 @@ protected:
     size_t el_index;
   };
 
+  struct NixStimulusInfo {
+    std::string name;
+    nix::MultiTag stimulus_mtag;
+    nix::DataArray positions_array, extents_array;
+    nix::DataArray time_feat, delay_feat, amplitude_feat, tag_feat;
+    std::map<std::string, nix::DataArray> stim_features, data_features;
+  };
 
   /*!
     \class NixFiles
@@ -514,14 +521,10 @@ protected:
     nix::File      fd;
     nix::Block     root_block;
     nix::Section   root_section;
-    nix::MultiTag  stimulus_tag;
     nix::Tag       repro_tag;
-    nix::DataArray stimulus_positions;
-    nix::DataArray stimulus_extents;
-    nix::DataArray time_feat, delay_feat, amplitude_feat, carrier_feat, tag_feat;
-    std::vector<nix::DataArray> data_features;
-    std::vector<nix::Feature> stimulus_feats;
     nix::Group     stimulus_group;
+    NixStimulusInfo current_stimulus_info;
+    std::map<std::string, NixStimulusInfo> stim_info_buffer;
 
     string create ( string path, bool compression );
     void close ( void );
@@ -529,7 +532,8 @@ protected:
     void saveMetadata ( const MetaData &mtdt );
     void createStimulusTag ( const std::string &repro_name, const Options &stimulus_options,
                              const Options &stimulus_features, const deque< OutDataInfo > &stim_info,
-                             const Acquire *AQ, double start_time, double duration );
+                             const Acquire *AQ, double start_time, double duration,
+			     NixStimulusInfo &info );
     void writeStimulus( const InList &IL, const EventList &EL,
 			const deque< OutDataInfo > &stimuliinfo,
 			const deque< bool > &newstimuli, const Options &data,

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -557,6 +557,7 @@ protected:
 				  std::string unit, std::string label,
 				  nix::LinkType link_type=nix::LinkType::Indexed,
                                   nix::DataType dtype = nix::DataType::Double );
+    void createFeaturesForOptions( const Options &options, std::string type );
     void storeOptionsToFeatures( const Options &options );
     
     string rid; //recording id

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -501,8 +501,7 @@ protected:
     std::string name;
     nix::MultiTag stimulus_mtag;
     nix::DataArray positions_array, extents_array;
-    nix::DataArray time_feat, delay_feat, amplitude_feat, tag_feat;
-    std::map<std::string, nix::DataArray> stim_features, data_features;
+    std::map< std::string, nix::DataArray > features;
   };
 
   /*!
@@ -524,7 +523,7 @@ protected:
     nix::Tag       repro_tag;
     nix::Group     stimulus_group;
     NixStimulusInfo current_stimulus_info;
-    std::map<std::string, NixStimulusInfo> stim_info_buffer;
+    std::map< std::string, NixStimulusInfo > stim_info_buffer;
 
     string create ( string path, bool compression );
     void close ( void );
@@ -545,7 +544,7 @@ protected:
 		      double sessiontime );
     void endRePro ( double current_time );
     void writeTraces ( const InList &IL );
-    void writeChunk ( NixTrace &trace, size_t to_read, const void *data);
+    void writeChunk ( NixTrace &trace, size_t to_read, const void *data );
     void initEvents ( const EventList &EL, FilterDetectors *FD );
     void writeEvents ( const InList &IL, const EventList &EL );
     void resetIndex ( const InList &IL );
@@ -557,11 +556,13 @@ protected:
 				  std::string name, std::string type,
 				  std::string unit, std::string label,
 				  nix::LinkType link_type=nix::LinkType::Indexed,
-                                  nix::DataType dtype = nix::DataType::Double);
+                                  nix::DataType dtype = nix::DataType::Double );
+    void storeOptionsToFeatures( const Options &options );
+    
     string rid; //recording id
 
-    vector<NixTrace> traces;
-    vector<NixEventData> events;
+    vector< NixTrace > traces;
+    vector< NixEventData > events;
   };
   NixFile NixIO;
   #endif

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -1803,17 +1803,9 @@ void SaveFiles::NixFile::close ( )
     root_block = nix::none;
     root_section = nix::none;
     repro_tag = nix::none;
-    stimulus_tag = nix::none;
-    stimulus_positions = nix::none;
-    stimulus_extents = nix::none;
     stimulus_group = nix::none;
-    tag_feat = nix::none;
-    time_feat = nix::none;
-    delay_feat = nix::none;
-    amplitude_feat = nix::none;
-    carrier_feat = nix::none;
-    data_features.clear();
-    stimulus_feats.clear();
+    stim_info_buffer.clear();
+    current_stimulus_info = NixStimulusInfo();
     traces.clear();
     events.clear();
     fd.close();
@@ -2057,13 +2049,13 @@ void SaveFiles::NixFile::endRePro( double current_time )
 {
   repro_tag.extent({ (current_time - repro_start_time)});
 
-  if ( stimulus_tag && (stimulus_start_time + stimulus_duration) > current_time ) {
+  if ( current_stimulus_info.stimulus_mtag && (stimulus_start_time + stimulus_duration) > current_time ) {
     double actual_duration =  current_time - stimulus_start_time - stepsize;
-    replaceLastEntry( stimulus_extents, actual_duration );
+    replaceLastEntry( current_stimulus_info.extents_array, actual_duration );
   }
 
-  if ( stimulus_group && stimulus_tag ){
-      stimulus_group.addMultiTag( stimulus_tag );
+  if ( stimulus_group && current_stimulus_info.stimulus_mtag ){
+      stimulus_group.addMultiTag( current_stimulus_info.stimulus_mtag );
   }
   repro_tag = nix::none;
   fd.flush();
@@ -2123,7 +2115,9 @@ void SaveFiles::NixFile::writeChunk(NixTrace   &trace,
 
 void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const Options &stim_options,
                                             const Options &stimulus_features, const deque< OutDataInfo > &stim_info,
-                                            const Acquire *AQ, double start_time, double duration ) {
+                                            const Acquire *AQ, double start_time, double duration,
+					    NixStimulusInfo &info )
+{
   nix::Section s;
   if ( repro_name.size() > 0 ) {
     string stim_name = stim_options.name();
@@ -2131,66 +2125,73 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const
     s = fd.createSection( stim_name, stim_type );
     saveNIXOptions( stim_options, s, Options::FirstOnly, 0 );
   }
-  stimulus_positions = root_block.createDataArray( repro_name + "_onset_times", "relacs.stimulus.onset",
-                                                   nix::DataType::Double, {1} );
+  info.positions_array = root_block.createDataArray( repro_name + "_onset_times",
+						     "relacs.stimulus.onset",
+						     nix::DataType::Double, {1} );
+  info.positions_array.setData( nix::DataType::Double, &start_time, {1}, {0} );
+  info.positions_array.appendSetDimension();
+  info.positions_array.unit( "s" );
+  info.positions_array.label( "time" );
+  
+  info.extents_array = root_block.createDataArray( repro_name + "_durations",
+						   "relacs.stimulus.duration",
+						   nix::DataType::Double, {1} );
+  info.extents_array.setData( nix::DataType::Double, &duration, {1}, {0} );
+  info.extents_array.appendSetDimension();
+  info.extents_array.unit( "s" );
+  info.extents_array.label( "time" );
 
-  stimulus_positions.setData( nix::DataType::Double, &start_time, {1}, {0} );
-  stimulus_positions.appendSetDimension();
-  stimulus_positions.unit( "s" );
-  stimulus_positions.label( "time" );
-
-  stimulus_extents = root_block.createDataArray( repro_name + "_durations", "relacs.stimulus.duration",
-                                                 nix::DataType::Double, {1} );
-  stimulus_extents.setData( nix::DataType::Double, &duration, {1}, {0} );
-  stimulus_extents.appendSetDimension();
-  stimulus_extents.unit( "s" );
-  stimulus_extents.label( "time" );
-
-  stimulus_tag = root_block.createMultiTag( repro_name, "relacs.stimulus.segment", stimulus_positions );
-  stimulus_tag.extents( stimulus_extents );
-  stimulus_tag.metadata( s );
+  info.stimulus_mtag = root_block.createMultiTag( repro_name, "relacs.stimulus.segment",
+						  info.positions_array );
+  info.stimulus_mtag.extents( info.extents_array );
+  info.stimulus_mtag.metadata( s );
   for ( auto &trace : traces ) {
-    stimulus_tag.addReference( trace.data );
+    info.stimulus_mtag.addReference( trace.data );
   }
   for ( auto &event : events ) {
     if ( event.input_trace < 0 ) {
       continue;
     }
-    stimulus_tag.addReference( event.data );
+    info.stimulus_mtag.addReference( event.data );
   }
+  info.name = repro_name;
+  
   // add features
   std::string fname;
   std::string funit;
   std::string flabel;
   std::string ftype;
-  data_features.clear();
+  info.data_features.clear();
   if ( !stimulus_features.empty() ) {
     for (auto o : stimulus_features) {
-        fname = stimulus_tag.name() + "_" + o.name();
-        funit = o.unit();
-        flabel = o.name();
-        ftype = "relacs.feature";
-        nix::DataType dtype;
-        if ( o.isNumber() ) {
-          dtype = nix::DataType::Double;
-        } else if ( o.isText() )  {
-          dtype = nix::DataType::String;
-        } else {
-          continue;
-        }
-        nix::DataArray da = createFeature( stimulus_tag, fname, ftype,
-                                           funit, flabel, nix::LinkType::Indexed, dtype );
-        data_features.push_back(da);
+      fname = info.stimulus_mtag.name() + "_" + o.name();
+      funit = o.unit();
+      flabel = o.name();
+      ftype = "relacs.feature";
+      nix::DataType dtype;
+      if ( o.isNumber() ) {
+	dtype = nix::DataType::Double;
+      } else if ( o.isText() )  {
+	dtype = nix::DataType::String;
+      } else {
+	continue;
+      }
+      nix::DataArray da = createFeature( info.stimulus_mtag, fname, ftype,
+					 funit, flabel, nix::LinkType::Indexed, dtype );
+      info.data_features[fname] = da;
     }
   }
-  fname =  stimulus_tag.name() + "_abs_time";
+  fname =  info.name + "_abs_time";
   funit = "s";
   flabel = "time";
   ftype = "relacs.time";
-  time_feat = createFeature( stimulus_tag, fname, ftype, funit, flabel, nix::LinkType::Indexed,  nix::DataType::Double );
-  fname =  stimulus_tag.name() + "_delay";
+  info.time_feat = createFeature( info.stimulus_mtag, fname, ftype, funit, flabel, nix::LinkType::Indexed,
+				  nix::DataType::Double );
+  
+  fname = info.name + "_delay";
   flabel = "delay";
-  delay_feat = createFeature(stimulus_tag, fname, ftype, funit, flabel, nix::LinkType::Indexed, nix::DataType::Double );
+  info.delay_feat = createFeature( info.stimulus_mtag, fname, ftype, funit, flabel, nix::LinkType::Indexed,
+				   nix::DataType::Double );
   std::string unit = "";
   for ( int k=0; k < AQ->outTracesSize(); k++ ) {
     if (stim_info[0].device() == AQ->outTrace(k).device() &&
@@ -2203,13 +2204,14 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const
       }
     }
   }
-  amplitude_feat = createFeature( stimulus_tag, stimulus_tag.name() + "_amplitude",
-                                 "relacs.feature.amplitude", unit, "intensity", nix::LinkType::Indexed, nix::DataType::Double);
-  for (Parameter p : stim_options) {
-    if ((p.flags() & OutData::Mutable) > 0) {
-      fname =  stimulus_tag.name() + "_" + p.name();
+  info.amplitude_feat = createFeature( info.stimulus_mtag, info.name + "_amplitude", "relacs.feature.amplitude",
+				       unit, "intensity", nix::LinkType::Indexed, nix::DataType::Double );
+  
+  for ( Parameter p : stim_options ) {
+    if ( (p.flags() & OutData::Mutable ) > 0) {
+      fname =  info.name + "_" + p.name();
       funit = p.unit();
-      nix::util::unitSanitizer(funit);
+      nix::util::unitSanitizer( funit );
       flabel = p.name();
       ftype = "relacs.feature.mutable";
       nix::DataType dtype;
@@ -2220,12 +2222,13 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const
       } else {
         continue;
       }
-      createFeature( stimulus_tag, fname, ftype, funit, flabel, nix::LinkType::Indexed, dtype);
+      info.stim_features[fname] = createFeature( info.stimulus_mtag, fname, ftype, funit, flabel,
+						 nix::LinkType::Indexed, dtype );
     }
   }
-  tag_feat = createFeature( stimulus_tag, stimulus_tag.name() + "_repro_tag_id", "relacs.feature.repro_tag_id", "", "id",
-                            nix::LinkType::Indexed, nix::DataType::String );
-  stimulus_feats = stimulus_tag.features();
+  info.tag_feat = createFeature( info.stimulus_mtag, info.name + "_repro_tag_id", "relacs.feature.repro_tag_id",
+				 "", "id", nix::LinkType::Indexed, nix::DataType::String );
+  //info.stim_features[(info.name + "_repro_tag_id")] = inf;  
 }
 
 
@@ -2241,83 +2244,63 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
   double abs_time = IL[0].signalTime() - sessiontime;
   double delay = stim_info[0].delay();
   double intensity = stim_info[0].intensity();
-
+  bool new_stim = false;
+  
   NixTrace trace = traces[0];
   stimulus_start_time = (IL[0].signalIndex() - trace.index  + trace.written) * stepsize;
   stimulus_duration = stim_info[0].length() - stepsize;
   string tag_name = nix::util::nameSanitizer(stim_info[0].description().name());
-
-  if ( stimulus_tag ) { // there is already a stimulus tag
-    if ( stimulus_tag.name() != tag_name ) { // it is NOT the one we need
-      stimulus_tag = root_block.getMultiTag(tag_name); // try to find it
-      if ( stimulus_tag ) {  // if a match was found, read the stuff
-        stimulus_positions = stimulus_tag.positions();
-        stimulus_extents = stimulus_tag.extents();
-        data_features.clear();
-        stimulus_feats = stimulus_tag.features();
-        for (nix::Feature f : stimulus_feats) {
-          if ( f.data().name() == tag_name + "_abs_time")
-            time_feat = f.data();
-          else if ( f.data().name() == tag_name + "_amplitude" )
-            amplitude_feat = f.data();
-          else if ( f.data().name() == tag_name + "_delay" )
-            delay_feat = f.data();
-          else if ( f.data().name() == tag_name + "_repro_tag_id" )
-            tag_feat = f.data();
-          else {
-            for (auto o : stim_options) {
-              if ( f.data().name() ==  tag_name + "_" + o.name()) {
-                data_features.push_back(f.data());
-              }
-            }
-          }
-        }
-      }
-    }
-    if ( stimulus_tag ) {
-      appendValue(stimulus_positions, stimulus_start_time);
-      appendValue(stimulus_extents, stimulus_duration);
+  
+  if ( current_stimulus_info.name != tag_name ) { // previous stimulus does not match the current
+    std::map<std::string, NixStimulusInfo>::iterator it;
+    it = stim_info_buffer.find(tag_name);
+    if ( it != stim_info_buffer.end() ) { // We have one in store, take it
+      current_stimulus_info = it->second;
+    } else { // no match, and not found, create a new one
+      current_stimulus_info = NixStimulusInfo();
+      createStimulusTag( tag_name, stim_info[0].description(), stim_options, stim_info,
+			 acquire, stimulus_start_time, stimulus_duration, current_stimulus_info );
+      stim_info_buffer[tag_name] = current_stimulus_info;
+      new_stim = true;
     }
   }
-  if ( !stimulus_tag ) { // there was no stimulus tag and no match was found, create a new one
-    createStimulusTag(tag_name, stim_info[0].description(), stim_options, stim_info,
-                      acquire, stimulus_start_time, stimulus_duration);
+  if ( !new_stim ) {
+    appendValue( current_stimulus_info.positions_array, stimulus_start_time );
+    appendValue( current_stimulus_info.extents_array, stimulus_duration );
   }
-  for ( auto o : stim_options ) { //TODO check if this can be simplified
-    for ( auto da : data_features ) {
-      if ( da.name() ==  tag_name + "_" + o.name()) {
-        if ( o.isNumber() ) {
+  //handle options that are stored as features
+  std::map<std::string, nix::DataArray>::iterator it;
+  for ( auto o : stim_options ) {
+    it = current_stimulus_info.data_features.find( tag_name + "_" + o.name() );
+    if ( it != current_stimulus_info.data_features.end() ){
+         if ( o.isNumber() ) {
           double val = o.number();
-          appendValue(da, val);
+          appendValue( it->second, val );
         } else if ( o.isText() ) {
           string val = o.text();
-          appendValue(da, val);
+          appendValue( it->second, val );
         }
-      }
     }
   }
   Options mutables = stimuliref[0].section( "parameter" );
   string prop_name;
   for (auto p : mutables) {
     prop_name = tag_name + "_" + p.name();
-    for (auto f : stimulus_feats) {
-      if (f.data().name() == prop_name) {
-        nix::DataArray da = f.data();
-        if ( p.isNumber() ) {
-          double val = p.number();
-          appendValue( da, val );
-        } else if ( p.isText() ) {
-          string val = p.text();
-          appendValue( da, val );
-        }
-        break;
-      }
+    it = current_stimulus_info.stim_features.find( prop_name );
+    if ( it != current_stimulus_info.stim_features.end() ) {
+      if ( p.isNumber() ) {
+	double val = p.number();
+	appendValue( it->second, val );
+      } else if ( p.isText() ) {
+	string val = p.text();
+	appendValue( it->second, val );
+      }    
     }
   }
-  appendValue( tag_feat, repro_tag_id );
-  appendValue( time_feat, abs_time );
-  appendValue( delay_feat, delay );
-  appendValue( amplitude_feat, intensity );
+  appendValue( current_stimulus_info.tag_feat, repro_tag_id );
+  appendValue( current_stimulus_info.time_feat, abs_time );
+  appendValue( current_stimulus_info.delay_feat, delay );
+  appendValue( current_stimulus_info.amplitude_feat, intensity );
   fd.flush();
 }
 


### PR DESCRIPTION
stimulus related nix entities, such as multiTags, position and extent arrays and linked features are buffered to search for stuff in memory instead of causing file-io.