### PR TITLE
support for multiple output channels

### DIFF
--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -109,13 +109,18 @@ private:
   bool start;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
-  
-  void setupTable(QGridLayout *grid);
+
+
+  void setupTable( QGridLayout *grid );
+  void updateTable( const TrialCondition &tc );
+  void updateUI( const TrialCondition &tc );
+
   void populateOptions();
+
   MazeCondition nextMazeCondition();
   TrialCondition nextTrialCondition();
   StimulusCondition nextStimulusConditions();
-  void updateUI(const TrialCondition &tc);
+
   void createStimuli();
   bool estimateEodFrequency( double &fisheodf );
   bool drawNonRewardedFrequency( double &freq );

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -42,6 +42,25 @@ namespace efield {
 enum class MazeOrientation {UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3};
 enum class MazeArm {NONE = -1, A = 0, B = 1, C = 2};
 enum class ArmCondition {REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2};
+
+struct MazeCondition {
+  MazeArm rewarded;
+  MazeArm unrewarded;
+  MazeArm neutral;
+};
+
+struct StimulusCondition {
+  double eodf;
+  double rewardedFreq;
+  double unrewardedFreq;
+  double rewardedAmplitude;
+  double unrewardedAmplitude;
+};
+
+struct TrialCondition {
+  MazeCondition mazeCondition;
+  StimulusCondition stimCondition;
+};
   
 class YMazeSketch : public QLabel
 {
@@ -77,6 +96,8 @@ public:
   virtual int main( void );
 
 private:
+  static const int START_TRIAL = 11, STOP_TRIAL = 12;
+
   YMazeSketch *sketch;
   double duration;
   double rewardedFreq;
@@ -87,9 +108,16 @@ private:
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   
   void setupTable(QGridLayout *grid);
+  MazeCondition nextMazeCondition();
+  
+  void createStimuli();
 
 private slots:
   void startNextTrial();
+  void stopTrial();
+  
+protected:
+  virtual void customEvent( QEvent *qce );
 };
 
 

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -77,13 +77,17 @@ public:
   virtual int main( void );
 
 private:
+  YMazeSketch *sketch;
   double duration;
   int numberOfTrials;
-  int lastRewardPosition;
+  int lastRewardPosition = -1;
   int currentRewardPosition;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
-
+  
   void setupTable(QGridLayout *grid);
+
+private slots:
+  void startNextTrial();
 };
 
 

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -111,11 +111,13 @@ private:
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
   OutList outList;
+  TrialCondition currentCondition;
+  std::map<MazeArm, int> armTraceMap;
   std::map<std::string, MazeArm> channelArmMap = {{"Arm-A", MazeArm::A},
 						  {"Arm-B", MazeArm::B},
 						  {"Arm-C", MazeArm::C}};
-  std::map<MazeArm, int> armTraceMap;
-  
+
+  std::string toString(const MazeArm &arm) const;
   void setupTable( QGridLayout *grid );
   void updateTable( const TrialCondition &tc );
   void updateUI( const TrialCondition &tc );

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -42,10 +42,11 @@ namespace efield {
 \author Jan Grewe
 \version 1.0 (Mar 18, 2020)
 */
-enum class MazeOrientation {UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3};
-enum class MazeArm {NONE = -1, A = 0, B = 1, C = 2};
-enum class ArmCondition {REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2};
-enum class BtnActions {NEXT_TRIAL = 11, START_TRIAL = 12, STOP_TRIAL = 13, STIM_READY = 14};
+enum class MazeOrientation { UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3 };
+enum class MazeArm { NONE = -1, A = 0, B = 1, C = 2 };
+enum class ArmCondition { REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2 };
+enum class BtnActions { NEXT_TRIAL = 11, START_TRIAL = 12, STOP_TRIAL = 13 };
+enum class YMazeEvents { STIM_READY = 14, IDLE = 15 };
 
 struct MazeCondition {
   MazeArm rewarded;
@@ -100,7 +101,7 @@ public:
 
 private:
   YMazeSketch *sketch;
-  double duration, eodf;
+  double duration, eodf, samplerate;
   double rewardedFreq;
   double freqRangeMin, freqRangeMax, minFreqDiff, deltaf;
   int numberOfTrials;
@@ -109,15 +110,12 @@ private:
   bool start;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
-  OutData signal_A, signal_B, signal_C;
   OutList outList;
   std::map<std::string, MazeArm> channelArmMap = {{"Arm-A", MazeArm::A},
 						  {"Arm-B", MazeArm::B},
 						  {"Arm-C", MazeArm::C}};
-  std::map<MazeArm, OutData> armSignalMap = {{MazeArm::A, signal_A},
-					    {MazeArm::B, signal_B},
-					    {MazeArm::C, signal_C}};
-
+  std::map<MazeArm, int> armTraceMap;
+  
   void setupTable( QGridLayout *grid );
   void updateTable( const TrialCondition &tc );
   void updateUI( const TrialCondition &tc );

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -1,0 +1,92 @@
+/*
+  efield/ymaze.h
+  Repro fro controlling discrimination experiments in a y-maze
+
+  RELACS - Relaxed ELectrophysiological data Acquisition, Control, and Stimulation
+  Copyright (C) 2002-2015 Jan Benda <jan.benda@uni-tuebingen.de>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  RELACS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RELACS_EFIELD_YMAZE_H_
+#define _RELACS_EFIELD_YMAZE_H_ 1
+
+#include <relacs/repro.h>
+#include <QLabel>
+#include <QObject>
+#include <QGridLayout>
+
+
+using namespace relacs;
+
+namespace efield {
+
+
+/*!
+\class YMaze
+\brief [RePro] Repro fro controlling discrimination experiments in a y-maze
+\author Jan Grewe
+\version 1.0 (Mar 18, 2020)
+*/
+enum class MazeOrientation {UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3};
+enum class MazeArm {NONE = -1, A = 0, B = 1, C = 2};
+enum class ArmCondition {REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2};
+  
+class YMazeSketch : public QLabel
+{
+  Q_OBJECT;
+
+public:
+  YMazeSketch(MazeOrientation orientation=MazeOrientation::UPRIGHT, QWidget *parent = nullptr);
+
+  void setCondition(MazeArm rewarded, MazeArm unrewarded, MazeArm neutral);
+
+private:
+  void setupUI();
+  void drawSketch();
+  void resizeEvent(QResizeEvent *event) override; 
+
+  MazeOrientation orientation;
+  MazeArm lastRewarded = MazeArm::NONE;
+  QLabel *l, *lbl1, *lbl2, *lbl3;
+  QLabel *labels[3];
+  QStringList colors = {"green","red","grey"};
+};
+
+
+
+  
+class YMaze : public RePro
+{
+  Q_OBJECT
+
+public:
+
+  YMaze( void );
+  virtual int main( void );
+
+private:
+  double duration;
+  int numberOfTrials;
+  int lastRewardPosition;
+  int currentRewardPosition;
+  QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
+
+  void setupTable(QGridLayout *grid);
+};
+
+
+}; /* namespace efield */
+
+#endif /* ! _RELACS_EFIELD_YMAZE_H_ */

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -110,6 +110,7 @@ private:
   void setupTable(QGridLayout *grid);
   MazeCondition nextMazeCondition();
   TrialCondition nextTrialCondition();
+  StimulusCondition nextStimulusConditions();
   void updateUI(const TrialCondition &tc);
   void createStimuli();
 

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -23,6 +23,9 @@
 #define _RELACS_EFIELD_YMAZE_H_ 1
 
 #include <relacs/repro.h>
+#include <relacs/efield/traces.h>
+#include <relacs/efield/eodtools.h>
+
 #include <QLabel>
 #include <QObject>
 #include <QGridLayout>
@@ -56,6 +59,7 @@ struct StimulusCondition {
   double unrewardedFreq;
   double rewardedAmplitude;
   double unrewardedAmplitude;
+  bool valid;
 };
 
 struct TrialCondition {
@@ -85,7 +89,7 @@ private:
 };
 
   
-class YMaze : public RePro
+  class YMaze : public RePro, public Traces, public EODTools
 {
   Q_OBJECT
 
@@ -96,22 +100,27 @@ public:
 
 private:
   YMazeSketch *sketch;
-  double duration;
+  double duration, eodf;
   double rewardedFreq;
-  double freqRangeMin, freqRangeMax, minFreqDiff;
+  double freqRangeMin, freqRangeMax, minFreqDiff, deltaf;
   int numberOfTrials;
   int lastRewardPosition = -1;
   int currentRewardPosition;
+  bool start;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
   
   void setupTable(QGridLayout *grid);
+  void populateOptions();
   MazeCondition nextMazeCondition();
   TrialCondition nextTrialCondition();
   StimulusCondition nextStimulusConditions();
   void updateUI(const TrialCondition &tc);
   void createStimuli();
-
+  bool estimateEodFrequency( double &fisheodf );
+  bool drawNonRewardedFrequency( double &freq );
+					       
+					       
 private slots:
   void startTrial();
   void stopTrial();

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -79,6 +79,8 @@ public:
 private:
   YMazeSketch *sketch;
   double duration;
+  double rewardedFreq;
+  double freqRangeMin, freqRangeMax, minFreqDiff;
   int numberOfTrials;
   int lastRewardPosition = -1;
   int currentRewardPosition;

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -42,6 +42,7 @@ namespace efield {
 enum class MazeOrientation {UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3};
 enum class MazeArm {NONE = -1, A = 0, B = 1, C = 2};
 enum class ArmCondition {REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2};
+enum class BtnActions {NEXT_TRIAL = 11, START_TRIAL = 12, STOP_TRIAL = 13};
 
 struct MazeCondition {
   MazeArm rewarded;
@@ -83,8 +84,6 @@ private:
   QStringList colors = {"green","red","grey"};
 };
 
-
-
   
 class YMaze : public RePro
 {
@@ -96,8 +95,6 @@ public:
   virtual int main( void );
 
 private:
-  static const int START_TRIAL = 11, STOP_TRIAL = 12;
-
   YMazeSketch *sketch;
   double duration;
   double rewardedFreq;
@@ -106,6 +103,7 @@ private:
   int lastRewardPosition = -1;
   int currentRewardPosition;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
+  QPushButton *nextBtn, *startBtn, *stopBtn;
   
   void setupTable(QGridLayout *grid);
   MazeCondition nextMazeCondition();
@@ -115,8 +113,9 @@ private:
   void createStimuli();
 
 private slots:
-  void startNextTrial();
+  void startTrial();
   void stopTrial();
+  void prepareNextTrial();
   
 protected:
   virtual void customEvent( QEvent *qce );

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -139,6 +139,7 @@ private slots:
   void prepareNextTrial();
   
 protected:
+  virtual void keyPressEvent( QKeyEvent *e );
   virtual void customEvent( QEvent *qce );
 };
 

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -67,14 +67,14 @@ class YMazeSketch : public QLabel
   Q_OBJECT;
 
 public:
-  YMazeSketch(MazeOrientation orientation=MazeOrientation::UPRIGHT, QWidget *parent = nullptr);
+  YMazeSketch( MazeOrientation orientation=MazeOrientation::UPRIGHT, QWidget *parent = nullptr );
 
-  void setCondition(MazeArm rewarded, MazeArm unrewarded, MazeArm neutral);
+  void setCondition( const MazeCondition &mazeCondition );
 
 private:
   void setupUI();
   void drawSketch();
-  void resizeEvent(QResizeEvent *event) override; 
+  void resizeEvent( QResizeEvent *event ) override; 
 
   MazeOrientation orientation;
   MazeArm lastRewarded = MazeArm::NONE;
@@ -109,7 +109,8 @@ private:
   
   void setupTable(QGridLayout *grid);
   MazeCondition nextMazeCondition();
-  
+  TrialCondition nextTrialCondition();
+  void updateUI(const TrialCondition &tc);
   void createStimuli();
 
 private slots:

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -45,7 +45,7 @@ namespace efield {
 enum class MazeOrientation {UPRIGHT = 0, BOTTOMUP = 1, LEFT = 2, RIGHT = 3};
 enum class MazeArm {NONE = -1, A = 0, B = 1, C = 2};
 enum class ArmCondition {REWARDED = 0, UNREWARDED = 1, NEUTRAL = 2};
-enum class BtnActions {NEXT_TRIAL = 11, START_TRIAL = 12, STOP_TRIAL = 13};
+enum class BtnActions {NEXT_TRIAL = 11, START_TRIAL = 12, STOP_TRIAL = 13, STIM_READY = 14};
 
 struct MazeCondition {
   MazeArm rewarded;
@@ -110,6 +110,7 @@ private:
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
   OutData signal_A, signal_B, signal_C;
+  OutList outList;
   std::map<std::string, MazeArm> channelArmMap = {{"Arm-A", MazeArm::A},
 						  {"Arm-B", MazeArm::B},
 						  {"Arm-C", MazeArm::C}};

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -109,23 +109,29 @@ private:
   bool start;
   QLabel *conditionA, *conditionApast, *conditionB, *conditionBpast, *conditionC, *conditionCpast;
   QPushButton *nextBtn, *startBtn, *stopBtn;
-
+  OutData signal_A, signal_B, signal_C;
+  std::map<std::string, MazeArm> channelArmMap = {{"Arm-A", MazeArm::A},
+						  {"Arm-B", MazeArm::B},
+						  {"Arm-C", MazeArm::C}};
+  std::map<MazeArm, OutData> armSignalMap = {{MazeArm::A, signal_A},
+					    {MazeArm::B, signal_B},
+					    {MazeArm::C, signal_C}};
 
   void setupTable( QGridLayout *grid );
   void updateTable( const TrialCondition &tc );
   void updateUI( const TrialCondition &tc );
 
   void populateOptions();
-
+  bool configureOutputTraces();
+  
   MazeCondition nextMazeCondition();
   TrialCondition nextTrialCondition();
   StimulusCondition nextStimulusConditions();
 
-  void createStimuli();
+  void createStimuli( const TrialCondition &tc );
   bool estimateEodFrequency( double &fisheodf );
   bool drawNonRewardedFrequency( double &freq );
-					       
-					       
+				       
 private slots:
   void startTrial();
   void stopTrial();

--- a/plugins/efield/include/relacs/efield/ymaze.h
+++ b/plugins/efield/include/relacs/efield/ymaze.h
@@ -101,6 +101,7 @@ public:
 
 private:
   YMazeSketch *sketch;
+  std::string name;
   double duration, eodf, samplerate;
   double rewardedFreq;
   double freqRangeMin, freqRangeMax, minFreqDiff, deltaf;

--- a/plugins/efield/relacs.cfg
+++ b/plugins/efield/relacs.cfg
@@ -96,7 +96,7 @@
       linewidth : 3
 
 *AudioMonitor
-  device   : [ "-1 default", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "7 hdmi (8 channels)", "8 pulse (32 channels)", "9 default (32 channels) - default" ]
+  device   : [ "-1 default", "0 HDA Intel PCH: ALC298 Analog (hw:0,0) (4 channels)", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "6 sysdefault (128 channels)", "7 front (4 channels)", "8 surround40 (4 channels)", "9 surround51 (4 channels)", "10 surround71 (4 channels)", "11 hdmi (8 channels)", "12 pulse (32 channels)", "13 dmix (2 channels)", "14 default (32 channels) - default" ]
   enable   : false
   mute     : false
   gain     : 1

--- a/plugins/efield/relacs.cfg
+++ b/plugins/efield/relacs.cfg
@@ -96,7 +96,7 @@
       linewidth : 3
 
 *AudioMonitor
-  device   : [ "-1 default", "0 HDA Intel PCH: ALC298 Analog (hw:0,0) (4 channels)", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "6 sysdefault (128 channels)", "7 front (4 channels)", "8 surround40 (4 channels)", "9 surround51 (4 channels)", "10 surround71 (4 channels)", "11 hdmi (8 channels)", "12 pulse (32 channels)", "13 dmix (2 channels)", "14 default (32 channels) - default" ]
+  device   : [ "-1 default", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "7 hdmi (8 channels)", "8 pulse (32 channels)", "9 default (32 channels) - default" ]
   enable   : false
   mute     : false
   gain     : 1

--- a/plugins/efield/relacs.cfg
+++ b/plugins/efield/relacs.cfg
@@ -96,7 +96,7 @@
       linewidth : 3
 
 *AudioMonitor
-  device   : [ "-1 default", "0 HDA Intel PCH: ALC3202 Analog (hw:0,0) (4 channels)", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 sysdefault (128 channels)", "5 front (4 channels)", "6 surround40 (4 channels)", "7 surround51 (4 channels)", "8 surround71 (4 channels)", "9 hdmi (8 channels)", "10 pulse (32 channels)", "11 dmix (2 channels)", "12 default (32 channels) - default", "13 /dev/dsp (16 channels)" ]
+  device   : [ "-1 default", "0 HDA Intel PCH: ALC298 Analog (hw:0,0) (4 channels)", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "6 sysdefault (128 channels)", "7 front (4 channels)", "8 surround40 (4 channels)", "9 surround51 (4 channels)", "10 surround71 (4 channels)", "11 hdmi (8 channels)", "12 pulse (32 channels)", "13 dmix (2 channels)", "14 default (32 channels) - default" ]
   enable   : false
   mute     : false
   gain     : 1

--- a/plugins/efield/relacsplugins.cfg
+++ b/plugins/efield/relacsplugins.cfg
@@ -274,8 +274,12 @@
   savetraces      : false
 
 *RePro: YMaze
-  duration: 1s
-  duration: 1000ms
+  duration   : 1s
+  rewardfreq : 1Hz
+  rangemin   : 1Hz
+  rangemax   : 1Hz
+  minfreqdiff: 10Hz
+  deltaf     : 10Hz
 
 *RePro: BaselineActivity
   Timing:

--- a/plugins/efield/relacsplugins.cfg
+++ b/plugins/efield/relacsplugins.cfg
@@ -278,8 +278,8 @@
   rewardfreq : 1Hz
   rangemin   : 1Hz
   rangemax   : 1Hz
-  minfreqdiff: 10Hz
   deltaf     : 10Hz
+  minfreqdiff: 10Hz
 
 *RePro: BaselineActivity
   Timing:

--- a/plugins/efield/relacsplugins.cfg
+++ b/plugins/efield/relacsplugins.cfg
@@ -2,7 +2,7 @@
   ephys: true
 
 *Control: SpectrumAnalyzer
-  intrace   : ~
+  intrace   : [ V-1, V-2, EOD-1, AM-1 ]
   origin    : [ before end of data, before signal, after signal ]
   offset    : 0ms
   duration  : 1000ms
@@ -55,6 +55,13 @@
       dioout   : false
       diodevice: dio-1
       dioline  : 0
+  Analog input traces:
+      trace-V-1  : true
+      trace-V-2  : true
+      trace-EOD-1: true
+      trace-AM-1 : true
+  Events:
+      events-EOD-1: true
 
 *RePro: SetAttenuatorGain
   outrace    : V-1
@@ -68,18 +75,18 @@
   interactive: false
 
 *RePro: SetInputGain
-  intrace    : ~
+  intrace    : [ V-1, V-2 ]
   gainindex  : 2
   interactive: true
 
 *RePro: SetOutput
-  outtrace   : ~
+  outtrace   : GlobalEField
   value      : 0V
   intensity  : 1
   interactive: false
 
 *RePro: Spectrogram
-  intrace : ~
+  intrace : [ V-1, V-2, EOD-1, AM-1 ]
   width   : 300ms
   step    : 150ms
   tmax    : 20s
@@ -94,7 +101,7 @@
 
 *RePro: TransferFunction
   Stimulus:
-      outtrace  : ~
+      outtrace  : GlobalEField
       offsetbase: [ custom, current ]value
       offset    : 0V
       amplitude : 1V
@@ -106,7 +113,7 @@
       pause     : 1s
       repeats   : 100
   Analysis:
-      intrace      : ~
+      intrace      : [ V-1, V-2, EOD-1, AM-1 ]
       size         : [ "1024", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536", "131072", "262144", "524288", "1048576" ]
       overlap      : true
       window       : [ Hanning, Bartlett, Blackman, Blackman-Harris, Hamming, Hanning, Parzen, Square, Welch ]
@@ -207,7 +214,7 @@
       scaling1: 1.000
       scaling2: 1.000
   EOD estimation:
-      intrace    : ~
+      intrace    : [ V-1, V-2, EOD-1, AM-1 ]
       usepsd     : true
       mineodfreq : 100Hz
       maxeodfreq : 2000Hz
@@ -255,7 +262,7 @@
   deltaf          : 0.0Hz
   lineardeltaf    : false
   deltaf2         : 0.0Hz
-  amplitude       : 0.01mV
+  amplitude       : 0.0mV
   duration        : 10seconds
   ramp            : 0.5seconds
   fakefish        : 600Hz
@@ -265,6 +272,10 @@
   averagetime     : 1seconds
   split           : false
   savetraces      : false
+
+*RePro: YMaze
+  duration: 1s
+  duration: 1000ms
 
 *RePro: BaselineActivity
   Timing:

--- a/plugins/efield/src/Makefile.am
+++ b/plugins/efield/src/Makefile.am
@@ -15,7 +15,8 @@ pluginlib_LTLIBRARIES = \
     libefieldmanualjar.la \
     libefieldeodmodel.la \
     libefielddualbeat.la \
-    libefieldbeats.la
+    libefieldbeats.la \
+    libefieldymaze.la
 
 
 if RELACS_COND_TML
@@ -564,6 +565,43 @@ libefieldcalibraterobot_la_include_HEADERS = $(HEADER_PATH)/calibraterobot.h
 
 
 
+libefieldymaze_la_CPPFLAGS = \
+    -I$(top_srcdir)/shapes/include \
+    -I$(top_srcdir)/daq/include \
+    -I$(top_srcdir)/numerics/include \
+    -I$(top_srcdir)/options/include \
+    -I$(top_srcdir)/datafile/include \
+    -I$(top_srcdir)/plot/include \
+    -I$(top_srcdir)/widgets/include \
+    -I$(top_srcdir)/relacs/include \
+    -I$(srcdir)/../include \
+    $(QT4_CPPFLAGS) $(NIX_CPPFLAGS)$(GSL_CPPFLAGS)
+
+libefieldymaze_la_LDFLAGS = \
+    -module -avoid-version \
+    $(QT4_LDFLAGS) $(NIX_LDFLAGS) $(GSL_LDFLAGS)
+
+libefieldymaze_la_LIBADD = \
+    $(top_builddir)/relacs/src/librelacs.la \
+    $(top_builddir)/widgets/src/librelacswidgets.la \
+    $(top_builddir)/plot/src/librelacsplot.la \
+    $(top_builddir)/datafile/src/librelacsdatafile.la \
+    $(top_builddir)/daq/src/librelacsdaq.la \
+    $(top_builddir)/options/src/librelacsoptions.la \
+    $(top_builddir)/shapes/src/librelacsshapes.la \
+    $(top_builddir)/numerics/src/librelacsnumerics.la \
+    $(QT4_LIBS) $(NIX_LIBS) $(GSL_LIBS)
+
+$(libefieldymaze_la_OBJECTS) : moc_ymaze.cc
+
+libefieldymaze_la_SOURCES = ymaze.cc
+
+libefieldymaze_la_includedir = $(pkgincludedir)/efield
+
+libefieldymaze_la_include_HEADERS = $(HEADER_PATH)/ymaze.h
+
+
+
 check_PROGRAMS = \
     linktest_libefieldeodtools_la \
     linktest_libefieldlinearfield_la \
@@ -576,7 +614,8 @@ check_PROGRAMS = \
     linktest_libefieldmanualjar_la \
     linktest_libefieldeodmodel_la \
     linktest_libefieldbeats_la \
-    linktest_libefielddualbeat_la
+    linktest_libefielddualbeat_la \
+    linktest_libefieldymaze_la
 
 if RELACS_COND_TML
 check_PROGRAMS += \
@@ -626,5 +665,8 @@ linktest_libefieldefieldgeometry_la_LDADD = libefieldefieldgeometry.la
 
 linktest_libefieldcalibraterobot_la_SOURCES = linktest.cc
 linktest_libefieldcalibraterobot_la_LDADD = libefieldcalibraterobot.la
+
+linktest_libefieldymaze_la_SOURCES = linktest.cc
+linktest_libefieldymaze_la_LDADD = libefieldymaze.la
 
 TESTS = $(check_PROGRAMS)

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -203,7 +203,7 @@ bool YMaze::estimateEodFrequency( double &fisheodf ) {
   fisheodf = number( "fakefisheodf" );
   if ( !boolean( "nofish" ) ) {
     if ( !boolean( "usepsd" ) ) {
-      fisheodf = events( EODEvents ).frequency( currentTime()-averagetime, currentTime() );
+      fisheodf = events( EODEvents ).frequency( currentTime() - averagetime, currentTime() );
       if ( EODEvents < 0 ) {
 	warning( "need EOD events of the EOD Trace." );
 	fisheodf = number( "fakefisheodf" );
@@ -216,9 +216,11 @@ bool YMaze::estimateEodFrequency( double &fisheodf ) {
       double min_eodf = number( "mineodfreq" );
       double max_eodf = number( "maxeodfreq" );
       double eodf_prec = number( "eodfreqprec" );
-      int intrace = index( "intrace" );
+      int intrace = index( "inputTrace" );
+      if ( intrace == -1 )
+	return false;
       int nfft = 1;
-	
+
       nfft = nextPowerOfTwo( (int)::ceil( 1.0/trace( intrace ).stepsize()/eodf_prec ) );
       eodf_prec = 1.0/trace( intrace ).stepsize()/nfft;
       if ( averagetime < 2.0/trace( intrace ).stepsize()/nfft ) {
@@ -285,6 +287,8 @@ bool YMaze::drawNonRewardedFrequency( double &freq ) {
   std::vector<double> freqs;
   double range = freqRangeMax - freqRangeMin;
   int steps = floor(range/deltaf);
+  if ( steps == 0 )
+    error( "Invalid frequency range, check options!" );
   int step = rand() % steps;
   freq = freqRangeMin + step * deltaf;
   int count = 0;
@@ -338,7 +342,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   rwStim.description().addText( "RewardedType", "rewarded" ).addFlags( OutData::Mutable );
   rwStim.description().addText( "Arm", toString(tc.mazeCondition.rewarded) ).addFlags( OutData::Mutable );
   rwStim.description()["Frequency"].addFlags( OutData::Mutable );
-  rwStim.setIdent( ident );
+  rwStim.setIdent( ident + "_rewarded" );
   outList.push( rwStim );
   
   // unrewarded stimulus
@@ -350,7 +354,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   nrwStim.description().addText( "RewardedType", "unrewarded" ).addFlags( OutData::Mutable );
   nrwStim.description().addText( "Arm", toString(tc.mazeCondition.unrewarded) ).addFlags( OutData::Mutable );
   nrwStim.description()["Frequency"].addFlags( OutData::Mutable );
-  nrwStim.setIdent( ident );
+  nrwStim.setIdent( ident + "_unrewarded" );
   outList.push( nrwStim );
   
   // neutral stimulus
@@ -361,7 +365,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   ntrlStim.description().addText( "RewardedType", "neutral" ).addFlags( OutData::Mutable );
   ntrlStim.description().addText( "Arm", toString(tc.mazeCondition.neutral) ).addFlags( OutData::Mutable );
   ntrlStim.description()["Frequency"].addFlags( OutData::Mutable );
-  ntrlStim.setIdent( ident );
+  ntrlStim.setIdent( ident + "_neutral" );
   outList.push( ntrlStim );
   
   postCustomEvent( static_cast<int>(YMazeEvents::STIM_READY) );

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -109,12 +109,16 @@ void YMazeSketch::setCondition(MazeArm rewarded, MazeArm unrewarded, MazeArm neu
 YMaze::YMaze( void )
   : RePro( "YMaze", "efield", "Jan Grewe", "1.0", "Mar 18, 2020" )
 {
-  addNumber( "duration", "trial duration", 1.0, 0.1, 1000., 10.0, "s" );
-  //  add
- // add some options:
-  addNumber( "duration", "Stimulus duration", 1.0, 0.001, 100000.0, 0.001, "s", "ms" );
-
-  // UI Layout
+  addNumber( "duration", "trial duration", 10.0, 0.1, 1000., 0.1, "s" );
+  addNumber( "rewardfreq", "rewarded frequency", 500.0, 1.0, 2500.0, 1.0, "Hz" );
+  addNumber( "rangemin", "Frequency range minimum", 1.0, 1.0, 2500.0, 1.0, "Hz" );
+  addNumber( "rangemax", "Frequency range maximum", 1000.0, 1.0, 2500.0, 1.0, "Hz" );
+  addNumber( "deltaf", "Stepsize of unrewarded stimulus frequency discretization",
+	     10.0, 1.0, 500.0, 1.0, "Hz" );
+  addNumber( "minfreqdiff", "Minimum frequency difference between rewarded and unrewarded stimulus",
+	     10.0, 1.0, 500.0, 1.0, "Hz" );
+  
+  // Ui Layout
   QGridLayout *grid = new QGridLayout();
   sketch = new YMazeSketch();
   grid->addWidget( sketch, 0, 0, 4, 4 );

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -319,6 +319,7 @@ TrialCondition YMaze::nextTrialCondition() {
   TrialCondition tc;
   tc.mazeCondition = nextMazeCondition();
   tc.stimCondition = nextStimulusConditions();
+  currentCondition = tc;
   return tc;
 }
   
@@ -464,6 +465,16 @@ bool YMaze::configureOutputTraces() {
   return success;
 }
 
+std::string YMaze::toString(const MazeArm &arm) const {
+  if (arm == MazeArm::A) {
+    return "Arm A";
+  } else if (arm == MazeArm::B) {
+    return "Arm B";
+  } else if (arm == MazeArm::C) {
+    return "Arm C";
+  }
+  return "";
+}
   
 //************************************************************************
 //************************************************************************
@@ -495,9 +506,9 @@ int YMaze::main( void ) {
         continue;
       }
       starttime = currentTime();
-      msg = "output!";
+      msg = "Stimulation is running.<br>Rewarded arm " + toString(currentCondition.mazeCondition.rewarded) ;
       message(msg);
-
+      
       startWrite( outList );
       bool error = false;
       for ( int i = 0; i < outList.size(); ++i ) {

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -308,6 +308,8 @@ StimulusCondition YMaze::nextStimulusConditions() {
   StimulusCondition sc;
   sc.rewardedFreq = rewardedFreq;
   sc.unrewardedFreq = noRewardFreq;
+  sc.rewardedAmplitude = number("rewardsignalampl");
+  sc.unrewardedAmplitude = number("nonrewardsignalampl");
   sc.valid = valid;
   return sc;
 }
@@ -335,7 +337,6 @@ void YMaze::stopTrial() {
 
 void YMaze::updateUI(const TrialCondition &tc) {
   sketch->setCondition( tc.mazeCondition );
-  // TODO update table with stimulus conditions
   conditionApast->setText(conditionA->text());
   conditionBpast->setText(conditionB->text());
   conditionCpast->setText(conditionC->text());
@@ -361,7 +362,7 @@ void YMaze::updateUI(const TrialCondition &tc) {
   
   if ( tc.mazeCondition.neutral == MazeArm::A )
     conditionA->setText( neutral );
-  else if ( tc.mazeCondition.unrewarded == MazeArm::B )
+  else if ( tc.mazeCondition.neutral == MazeArm::B )
     conditionB->setText( neutral );
   else
     conditionC->setText( neutral );

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -1,0 +1,172 @@
+/*
+  efield/ymaze.cc
+  Repro fro controlling discrimination experiments in a y-maze
+
+  RELACS - Relaxed ELectrophysiological data Acquisition, Control, and Stimulation
+  Copyright (C) 2002-2015 Jan Benda <jan.benda@uni-tuebingen.de>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  RELACS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <relacs/efield/ymaze.h>
+#include <QPainter>
+#include <QPicture>
+#include <QPushButton>
+#include <iostream>
+
+using namespace relacs;
+
+namespace efield {
+
+YMazeSketch::YMazeSketch(MazeOrientation orientation, QWidget *parent) :
+  QLabel(parent), orientation(orientation) {
+    setupUI();
+}
+
+void YMazeSketch::setupUI() {
+  QGridLayout *grid = new QGridLayout();
+  l = new QLabel();
+
+  lbl1 = new QLabel( "A" );
+  lbl1->setFixedSize( 24, 24);
+  lbl1->setAlignment( Qt::AlignLeft );
+
+  lbl2 = new QLabel( "B" );
+  lbl2->setFixedSize( 24, 24 );
+  lbl2->setAlignment( Qt::AlignLeft );
+
+  lbl3 = new QLabel( "C" );
+  lbl3->setFixedSize( 24, 24 );
+  lbl3->setAlignment( Qt::AlignLeft );
+  drawSketch();
+
+  labels[0] = lbl1;
+  labels[1] = lbl2;
+  labels[2] = lbl3;
+
+  grid->addWidget( lbl1, 0, 0, 1, 1, Qt::AlignCenter );
+  grid->addWidget( lbl2, 0, 4, 1, 1, Qt::AlignCenter );
+  grid->addWidget( lbl3, 4, 2, 1, 1, Qt::AlignCenter );
+  grid->addWidget( l, 1, 0, 3, 5, Qt::AlignCenter );
+
+  this->setLayout(grid);
+}
+
+void YMazeSketch::drawSketch() {
+  int width = this->width();
+  int height = l->height();
+  int centerx = width / 2;
+  int centery = height / 2;
+  int xstart = width / 10;
+  int xend = width - xstart;
+
+  l->clear();
+  QPicture pi;
+  QPainter p(&pi);
+  p.setRenderHint(QPainter::Antialiasing);
+  p.setPen(QPen(Qt::black, 12, Qt::SolidLine, Qt::RoundCap));
+  p.drawLine(xstart, 0, centerx, centery);
+  p.drawLine(xend, 0, centerx, centery);
+  p.drawLine(centerx, height, centerx, centery);
+  p.end();
+  l->setPicture(pi);
+}
+
+void YMazeSketch::resizeEvent(QResizeEvent *event) {
+  drawSketch();
+  QLabel::resizeEvent(event);
+}
+
+
+void YMazeSketch::setCondition(MazeArm rewarded, MazeArm unrewarded, MazeArm neutral) {
+  QString styleStub = "QLabel{font-size: 20; font-weight: bold; color : ";
+  QString styleSuffix = "}";
+  labels[static_cast<int>(rewarded)]->setStyleSheet(styleStub +
+						    colors[static_cast<int>(ArmCondition::REWARDED)] +
+						    styleSuffix);
+ labels[static_cast<int>(unrewarded)]->setStyleSheet(styleStub +
+						     colors[static_cast<int>(ArmCondition::UNREWARDED)] +
+						     styleSuffix);
+  labels[static_cast<int>(neutral)]->setStyleSheet(styleStub +
+						  colors[static_cast<int>(ArmCondition::NEUTRAL)] +
+						  styleSuffix);
+
+}
+
+//***********************************************************************
+//***********************************************************************  
+YMaze::YMaze( void )
+  : RePro( "YMaze", "efield", "Jan Grewe", "1.0", "Mar 18, 2020" )
+{
+  addNumber( "duration", "trial duration", 1.0, 0.1, 1000., 10.0, "s" );
+  //  add
+ // add some options:
+  addNumber( "duration", "Stimulus duration", 1.0, 0.001, 100000.0, 0.001, "s", "ms" );
+
+  // UI Layout
+  QGridLayout *grid = new QGridLayout();
+  YMazeSketch *sketch = new YMazeSketch();
+  grid->addWidget( sketch, 0, 0, 4, 4 );
+  setupTable(grid);
+  QPushButton *startBtn = new QPushButton("Start");
+  grid->addWidget( startBtn, 4, 5, 1, 1 );
+  this->setLayout( grid );  
+}
+
+void YMaze::setupTable(QGridLayout *grid) {
+  QString activeStyle = "QLabel{color: grey}";
+  QString passiveStyle = "QLabel{color: black}";
+  conditionA = new QLabel( "" );
+  conditionB = new QLabel( "" );
+  conditionC = new QLabel( "" );
+  conditionA->setStyleSheet( activeStyle );
+  conditionB->setStyleSheet( activeStyle );
+  conditionC->setStyleSheet( activeStyle );
+  
+  conditionApast = new QLabel( "" );
+  conditionBpast = new QLabel( "" );
+  conditionCpast = new QLabel( "" );
+  conditionApast->setStyleSheet( passiveStyle );
+  conditionBpast->setStyleSheet( passiveStyle );
+  conditionCpast->setStyleSheet( passiveStyle );
+
+  grid->addWidget( new QLabel("current:"), 0, 6, 1, 1 );
+  grid->addWidget( new QLabel("past:"), 0, 7, 1, 1 );
+  
+  grid->addWidget( new QLabel("A:"), 1, 5, 1, 1 );
+  grid->addWidget( conditionA, 1, 6, 1, 1 );
+  grid->addWidget( conditionApast, 1, 7, 1, 1);
+  
+  grid->addWidget( new QLabel("B:"), 2, 5, 1, 1 );
+  grid->addWidget( conditionB, 2, 6, 1, 1 );
+  grid->addWidget( conditionBpast, 2, 7, 1, 1);
+
+  grid->addWidget( new QLabel("C:"), 3, 5, 1, 1 );
+  grid->addWidget( conditionC, 3, 6, 1, 1 );
+  grid->addWidget( conditionCpast, 3, 7, 1, 1);
+}
+
+int YMaze::main( void )
+{
+  // get options:
+  duration = number( "duration" );
+  return Completed;
+}
+
+
+addRePro( YMaze, efield );
+
+}; /* namespace efield */
+
+#include "moc_ymaze.cc"

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -140,6 +140,7 @@ YMaze::YMaze( void )
 
 void YMaze::populateOptions() {
   newSection( "Experiment" );
+  addText( "name" , "Prefix used to identify the repro run, auto-generated if empty", "" );
   addNumber( "duration", "Trial duration", 10.0, 0.1, 1000., 0.1, "s" );
   addNumber( "samplerate", "stimulus sampling rate", 20000, 1000., 100000., 100., "Hz" );
   addNumber( "rewardfreq", "Rewarded frequency", 500.0, 1.0, 2500.0, 1.0, "Hz" );
@@ -324,6 +325,7 @@ TrialCondition YMaze::nextTrialCondition() {
 }
   
 void YMaze::createStimuli( const TrialCondition &tc ) {
+  string ident = name.size() == 0 ? "Ymaze" : name;
   outList.clear();
   double sampleInterval = 1./samplerate;
 
@@ -336,6 +338,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   rwStim.description().addText( "RewardedType", "rewarded" ).addFlags( OutData::Mutable );
   rwStim.description().addText( "Arm", toString(tc.mazeCondition.rewarded) ).addFlags( OutData::Mutable );
   rwStim.description()["Frequency"].addFlags( OutData::Mutable );
+  rwStim.setIdent( ident );
   outList.push( rwStim );
   
   // unrewarded stimulus
@@ -347,7 +350,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   nrwStim.description().addText( "RewardedType", "unrewarded" ).addFlags( OutData::Mutable );
   nrwStim.description().addText( "Arm", toString(tc.mazeCondition.unrewarded) ).addFlags( OutData::Mutable );
   nrwStim.description()["Frequency"].addFlags( OutData::Mutable );
-
+  nrwStim.setIdent( ident );
   outList.push( nrwStim );
   
   // neutral stimulus
@@ -358,7 +361,7 @@ void YMaze::createStimuli( const TrialCondition &tc ) {
   ntrlStim.description().addText( "RewardedType", "neutral" ).addFlags( OutData::Mutable );
   ntrlStim.description().addText( "Arm", toString(tc.mazeCondition.neutral) ).addFlags( OutData::Mutable );
   ntrlStim.description()["Frequency"].addFlags( OutData::Mutable );
-
+  ntrlStim.setIdent( ident );
   outList.push( ntrlStim );
   
   postCustomEvent( static_cast<int>(YMazeEvents::STIM_READY) );
@@ -506,7 +509,6 @@ void YMaze::keyPressEvent( QKeyEvent *e ) {
 //************************************************************************
 //************************************************************************
 int YMaze::main( void ) {
-  double starttime = currentTime();
   string msg;
   
   duration = number( "duration" );
@@ -516,6 +518,7 @@ int YMaze::main( void ) {
   freqRangeMax = number( "rangemax" );
   minFreqDiff = number( "minfreqdiff" );
   deltaf = number( "deltaf" );
+  name = text( "name" );
   start = false;
 
   bool success = configureOutputTraces();
@@ -533,7 +536,6 @@ int YMaze::main( void ) {
         sleep(0.2);
         continue;
       }
-      starttime = currentTime();
       msg = "Stimulation is running.<br>Rewarded arm is " + toString(currentCondition.mazeCondition.rewarded) ;
       message(msg);
       write( outList );

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -335,8 +335,18 @@ void YMaze::stopTrial() {
   postCustomEvent ( static_cast<int>(BtnActions::STOP_TRIAL) );
 }
 
-void YMaze::updateUI(const TrialCondition &tc) {
+
+void YMaze::updateUI( const TrialCondition &tc ) {
   sketch->setCondition( tc.mazeCondition );
+  updateTable( tc );
+}
+
+
+void YMaze::updateTable( const TrialCondition &tc ) {
+  QString rwrdStyle = "QLabel{color: green; font-size: 8pt; font-weight: bold}";
+  QString ntrlStyle = "QLabel{color: black; font-size: 8pt; font-weight: bold}";
+  QString nrwrdStyle = "QLabel{color: red; font-size: 8pt; font-weight: bold}";
+  
   conditionApast->setText(conditionA->text());
   conditionBpast->setText(conditionB->text());
   conditionCpast->setText(conditionC->text());
@@ -346,28 +356,40 @@ void YMaze::updateUI(const TrialCondition &tc) {
     QString::number(tc.stimCondition.unrewardedAmplitude) + "mV";
   QString neutral = "---";
   
-  if ( tc.mazeCondition.rewarded == MazeArm::A )
+  if ( tc.mazeCondition.rewarded == MazeArm::A ) {
     conditionA->setText( rf );
-  else if ( tc.mazeCondition.rewarded == MazeArm::B )
+    conditionA->setStyleSheet( rwrdStyle );
+  } else if ( tc.mazeCondition.rewarded == MazeArm::B ) {
     conditionB->setText( rf );
-  else
+    conditionB->setStyleSheet( rwrdStyle );
+  } else {
     conditionC->setText( rf );
+    conditionC->setStyleSheet( rwrdStyle );
+  }
 
-  if ( tc.mazeCondition.unrewarded == MazeArm::A )
+  if ( tc.mazeCondition.unrewarded == MazeArm::A ) {
     conditionA->setText( uf );
-  else if ( tc.mazeCondition.unrewarded == MazeArm::B )
+    conditionA->setStyleSheet( nrwrdStyle );
+  } else if ( tc.mazeCondition.unrewarded == MazeArm::B ) {
     conditionB->setText( uf );
-  else
+    conditionB->setStyleSheet( nrwrdStyle );
+  } else {
     conditionC->setText( uf );
+    conditionC->setStyleSheet( nrwrdStyle );
+  }
   
-  if ( tc.mazeCondition.neutral == MazeArm::A )
+  if ( tc.mazeCondition.neutral == MazeArm::A ) {
     conditionA->setText( neutral );
-  else if ( tc.mazeCondition.neutral == MazeArm::B )
+    conditionA->setStyleSheet( ntrlStyle );
+  } else if ( tc.mazeCondition.neutral == MazeArm::B ) {
     conditionB->setText( neutral );
-  else
+    conditionB->setStyleSheet( ntrlStyle );
+  } else {
     conditionC->setText( neutral );
-
+    conditionC->setStyleSheet( ntrlStyle );
+  }
 }
+
 
 void YMaze::customEvent( QEvent *qce ) {
   TrialCondition tc;
@@ -375,7 +397,7 @@ void YMaze::customEvent( QEvent *qce ) {
   case static_cast<int>(BtnActions::NEXT_TRIAL):
     std::cerr << "perpare next trial!" << std::endl;
     tc = nextTrialCondition();
-    updateUI(tc);
+    updateUI( tc );
     nextBtn->setEnabled(false);
     startBtn->setEnabled(true);
     break;

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -122,13 +122,18 @@ YMaze::YMaze( void )
   sketch = new YMazeSketch();
   grid->addWidget( sketch, 0, 0, 4, 4 );
   setupTable(grid);
-  QPushButton *startBtn = new QPushButton("Start");
-  connect( startBtn, SIGNAL( clicked() ), this, SLOT( startNextTrial() ) );
+
+  startBtn = new QPushButton("Start");
+  connect( startBtn, SIGNAL( clicked() ), this, SLOT( startTrial() ) );
   grid->addWidget( startBtn, 4, 5, 1, 1 );
 
-  QPushButton *stopBtn = new QPushButton("Stop");
+  stopBtn = new QPushButton("Stop");
   connect( stopBtn, SIGNAL( clicked() ), this, SLOT( stopTrial() ) );
   grid->addWidget( stopBtn, 5, 5, 1, 1 );
+
+  nextBtn = new QPushButton("Prepare next");
+  connect( nextBtn, SIGNAL( clicked() ), this, SLOT( prepareNextTrial() ) );
+  grid->addWidget( startBtn, 4, 5, 1, 1 );
 
   this->setLayout( grid );  
 }
@@ -208,12 +213,16 @@ TrialCondition YMaze::nextTrialCondition() {
   
 void createStimuli() {};
   
-void YMaze::startNextTrial() {
-  postCustomEvent( START_TRIAL );
+void YMaze::startTrial() {
+  postCustomEvent( static_cast<int>(BtnActions::START_TRIAL) );
+}
+
+void YMaze::prepareNextTrial() {
+  postCustomEvent( static_cast<int>(BtnActions::NEXT_TRIAL) );
 }
 
 void YMaze::stopTrial() {
-  postCustomEvent ( STOP_TRIAL );
+  postCustomEvent ( static_cast<int>(BtnActions::STOP_TRIAL) );
 }
 
 void YMaze::updateUI(const TrialCondition &tc) {
@@ -224,13 +233,19 @@ void YMaze::updateUI(const TrialCondition &tc) {
 void YMaze::customEvent( QEvent *qce ) {
   TrialCondition tc;
   switch ( qce->type() - QEvent::User ) {
-  case START_TRIAL:
-    std::cerr << "Trial start!" << std::endl;
+  case static_cast<int>(BtnActions::NEXT_TRIAL):
+    std::cerr << "perpare next trial!" << std::endl;
     tc = nextTrialCondition();
     updateUI(tc);
+    
     break;
-  case STOP_TRIAL:
-    std::cerr << "Trial stop!" << std::endl;
+
+  case static_cast<int>(BtnActions::START_TRIAL):
+    std::cerr << "start trial!" << std::endl;
+    
+    break;
+  case static_cast<int>(BtnActions::STOP_TRIAL):
+    std::cerr << "stop trial!" << std::endl;
     break;
   default:
     break;
@@ -245,7 +260,7 @@ void YMaze::customEvent( QEvent *qce ) {
 int YMaze::main( void ) {
   // get options:
   duration = number( "duration" );
-  
+  rewardedFreq = number("rewarded");
   bool start = false;
   while ( softStop() == 0 ) {
       if ( interrupt() || softStop() > 0 )

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -321,7 +321,11 @@ TrialCondition YMaze::nextTrialCondition() {
   return tc;
 }
   
-void createStimuli() {};
+void YMaze::createStimuli( const TrialCondition &tc ) {
+  std::cerr << "createStimuli" << std::endl;
+  
+ 
+}
   
 void YMaze::startTrial() {
   postCustomEvent( static_cast<int>(BtnActions::START_TRIAL) );
@@ -397,6 +401,7 @@ void YMaze::customEvent( QEvent *qce ) {
   case static_cast<int>(BtnActions::NEXT_TRIAL):
     std::cerr << "perpare next trial!" << std::endl;
     tc = nextTrialCondition();
+    createStimuli( tc ); 
     updateUI( tc );
     nextBtn->setEnabled(false);
     startBtn->setEnabled(true);
@@ -418,9 +423,25 @@ void YMaze::customEvent( QEvent *qce ) {
   } 
 }
 
-//************************************************************************
-//************************************************************************
 
+bool YMaze::configureOutputTraces() {
+  bool success = true;
+  for (int i = 0; i < outTracesSize(); ++i) {
+    std::string name = outTraceName( i );
+    std::map<std::string, MazeArm>::iterator it = channelArmMap.find( name );
+    if (it != channelArmMap.end()) {
+      armSignalMap[it->second].setTrace( i );
+    } else {
+      success = false;
+      break;
+    }
+  }
+  return success;
+}
+
+  
+//************************************************************************
+//************************************************************************
 int YMaze::main( void ) {
   // get options:
   duration = number( "duration" );
@@ -430,6 +451,11 @@ int YMaze::main( void ) {
   minFreqDiff = number( "minfreqdiff" );
   deltaf = number( "deltaf" );
   start = false;
+  bool success = configureOutputTraces();
+  if (!success) {
+    warning("configuration of output channels failed!");
+    return Failed;
+  }
 
   while ( softStop() == 0 ) {
       if ( interrupt() || softStop() > 0 )

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -192,10 +192,9 @@ MazeCondition YMaze::nextMazeCondition() {
   return mazeCondition;
 }
 
-
-StimulusConditions nextStimulusConditions() {
+StimulusCondition YMaze::nextStimulusConditions() {
   StimulusCondition sc;
-  sc.rewadedFreq = rewardedFreq;
+  sc.rewardedFreq = rewardedFreq;
 
   return sc;
 }
@@ -203,7 +202,7 @@ StimulusConditions nextStimulusConditions() {
 TrialCondition YMaze::nextTrialCondition() {
   TrialCondition tc;
   tc.mazeCondition = nextMazeCondition();
-  tc.stimCondition = nextStimulusconditions();
+  tc.stimCondition = nextStimulusConditions();
   return tc;
 }
   

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -96,9 +96,9 @@ void YMazeSketch::setCondition( const MazeCondition &mc ) {
   labels[static_cast<int>(mc.rewarded)]->setStyleSheet(styleStub +
 						       colors[static_cast<int>(ArmCondition::REWARDED)] +
 						       styleSuffix);
- labels[static_cast<int>(mc.unrewarded)]->setStyleSheet(styleStub +
-							colors[static_cast<int>(ArmCondition::UNREWARDED)] +
-							styleSuffix);
+  labels[static_cast<int>(mc.unrewarded)]->setStyleSheet(styleStub +
+							 colors[static_cast<int>(ArmCondition::UNREWARDED)] +
+							 styleSuffix);
   labels[static_cast<int>(mc.neutral)]->setStyleSheet(styleStub +
 						      colors[static_cast<int>(ArmCondition::NEUTRAL)] +
 						      styleSuffix);
@@ -163,8 +163,8 @@ void YMaze::populateOptions() {
 }
   
 void YMaze::setupTable(QGridLayout *grid) {
-  QString activeStyle = "QLabel{color: grey}";
-  QString passiveStyle = "QLabel{color: black}";
+  QString activeStyle = "QLabel{color: red; font-size: 8pt}";
+  QString passiveStyle = "QLabel{color: black; font-size: 8pt}";
   conditionA = new QLabel( "" );
   conditionB = new QLabel( "" );
   conditionC = new QLabel( "" );
@@ -336,6 +336,36 @@ void YMaze::stopTrial() {
 void YMaze::updateUI(const TrialCondition &tc) {
   sketch->setCondition( tc.mazeCondition );
   // TODO update table with stimulus conditions
+  conditionApast->setText(conditionA->text());
+  conditionBpast->setText(conditionB->text());
+  conditionCpast->setText(conditionC->text());
+  QString rf = QString::number(tc.stimCondition.rewardedFreq) + "Hz;\n " +
+    QString::number(tc.stimCondition.rewardedAmplitude) + "mV";
+  QString uf = QString::number(tc.stimCondition.unrewardedFreq) + "Hz;\n " +
+    QString::number(tc.stimCondition.unrewardedAmplitude) + "mV";
+  QString neutral = "---";
+  
+  if ( tc.mazeCondition.rewarded == MazeArm::A )
+    conditionA->setText( rf );
+  else if ( tc.mazeCondition.rewarded == MazeArm::B )
+    conditionB->setText( rf );
+  else
+    conditionC->setText( rf );
+
+  if ( tc.mazeCondition.unrewarded == MazeArm::A )
+    conditionA->setText( uf );
+  else if ( tc.mazeCondition.unrewarded == MazeArm::B )
+    conditionB->setText( uf );
+  else
+    conditionC->setText( uf );
+  
+  if ( tc.mazeCondition.neutral == MazeArm::A )
+    conditionA->setText( neutral );
+  else if ( tc.mazeCondition.unrewarded == MazeArm::B )
+    conditionB->setText( neutral );
+  else
+    conditionC->setText( neutral );
+
 }
 
 void YMaze::customEvent( QEvent *qce ) {

--- a/plugins/efield/src/ymaze.cc
+++ b/plugins/efield/src/ymaze.cc
@@ -116,10 +116,11 @@ YMaze::YMaze( void )
 
   // UI Layout
   QGridLayout *grid = new QGridLayout();
-  YMazeSketch *sketch = new YMazeSketch();
+  sketch = new YMazeSketch();
   grid->addWidget( sketch, 0, 0, 4, 4 );
   setupTable(grid);
   QPushButton *startBtn = new QPushButton("Start");
+  connect( startBtn, SIGNAL( clicked() ), this, SLOT( startNextTrial() ) );
   grid->addWidget( startBtn, 4, 5, 1, 1 );
   this->setLayout( grid );  
 }
@@ -157,10 +158,45 @@ void YMaze::setupTable(QGridLayout *grid) {
   grid->addWidget( conditionCpast, 3, 7, 1, 1);
 }
 
+
+void YMaze::startNextTrial() {
+  int nextPosition = rand() %3;
+  while ( nextPosition == lastRewardPosition ) {
+    nextPosition = rand() %3;
+  }
+  std::vector<MazeArm> arms = {MazeArm::A, MazeArm::B, MazeArm::C};
+  MazeArm rewarded, unrewarded, neutral;
+  if (lastRewardPosition == static_cast<int> (MazeArm::NONE ) ) {
+    rewarded = arms[nextPosition];
+    arms.erase(arms.begin() + nextPosition);
+    unrewarded = arms[0];
+    neutral = arms[1];
+    lastRewardPosition = nextPosition;
+  } else {
+    rewarded = arms[nextPosition];
+    neutral = arms[lastRewardPosition];
+    arms.erase( arms.begin() + nextPosition );
+    arms.erase( std::find( arms.begin(), arms.end(), static_cast<MazeArm>( lastRewardPosition ) ) );
+    unrewarded = arms[0];
+    lastRewardPosition = nextPosition;
+  }
+  sketch->setCondition( rewarded, unrewarded, neutral );
+}
+
+
 int YMaze::main( void )
 {
   // get options:
   duration = number( "duration" );
+  bool start = false;
+  while ( softStop() == 0 ) {
+      if ( interrupt() || softStop() > 0 )
+        break;
+      if ( !start ){
+        sleep(0.2);
+        continue;
+      }
+  }
   return Completed;
 }
 

--- a/plugins/efish/relacs.cfg
+++ b/plugins/efish/relacs.cfg
@@ -12,8 +12,6 @@
   Save:
       saverelacsfiles  : true
       saveodmlfiles    : false
-      savenixfiles     : true
-      savenixcompressed: true
       saverelacscore   : true
       saverelacsplugins: true
       saverelacslog    : true
@@ -131,9 +129,9 @@
       storewidth     : false
 
 *AudioMonitor
-  device   : [ "-1 default", "0 HDA Intel HDMI: 0 (hw:0,3) (8 channels)", "1 HDA Intel HDMI: 1 (hw:0,7) (8 channels)", "2 HDA Intel HDMI: 2 (hw:0,8) (8 channels)", "3 HDA Intel PCH: ALC671 Analog (hw:1,0) (2 channels)", "6 hdmi (8 channels)", "7 pulse (32 channels)", "8 default (32 channels) - default" ]
+  device   : [ "-1 default", "-1 default", "0 HDA Intel PCH: ALC298 Analog (hw:0,0) (4 channels)", "1 HDA Intel PCH: HDMI 0 (hw:0,3) (8 channels)", "2 HDA Intel PCH: HDMI 1 (hw:0,7) (8 channels)", "3 HDA Intel PCH: HDMI 2 (hw:0,8) (8 channels)", "4 HDA Intel PCH: HDMI 3 (hw:0,9) (8 channels)", "5 HDA Intel PCH: HDMI 4 (hw:0,10) (8 channels)", "6 sysdefault (128 channels)", "7 front (4 channels)", "8 surround40 (4 channels)", "9 surround51 (4 channels)", "10 surround71 (4 channels)", "11 hdmi (8 channels)", "12 pulse (32 channels)", "13 dmix (2 channels)", "14 default (32 channels) - default" ]
   enable   : true
-  mute     : false
+  mute     : true
   gain     : 1
   audiorate: [ "44.1", "8", "16", "22.05", "44.1", "48", "96" ]kHz
 

--- a/plugins/efish/relacsplugins.cfg
+++ b/plugins/efish/relacsplugins.cfg
@@ -199,11 +199,11 @@
   interpolation: [ linear interpolation, closest datapoint, linear interpolation, linear fit, quadratic fit ]
 
 *Event Detector: LocalBeat-1
-  minthresh: 0.025mV
+  minthresh: 0.050mV
   ratio    : 35%
 
 *Event Detector: GlobalEFieldStimulus
-  threshold    : 0.05mV
+  threshold    : 0.16638mV
   interpolation: [ linear interpolation, closest datapoint, linear interpolation, linear fit, quadratic fit ]
 
 *RePro: Pause

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -557,7 +557,7 @@ protected:
 				  std::string unit, std::string label,
 				  nix::LinkType link_type=nix::LinkType::Indexed,
                                   nix::DataType dtype = nix::DataType::Double );
-    void createFeaturesForOptions( const Options &options, std::string type );
+    void createFeaturesForOptions( const Options &options, const std::string &type, const std::string &name_prefix );
     void storeOptionsToFeatures( const Options &options );
     
     string rid; //recording id

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -557,7 +557,7 @@ protected:
 				  nix::LinkType link_type=nix::LinkType::Indexed,
                                   nix::DataType dtype = nix::DataType::Double );
     void createFeaturesForOptions( const Options &options, const std::string &type, const std::string &name_prefix );
-    void storeOptionsToFeatures( const Options &options );
+    void storeOptionsToFeatures( const Options &options , const std::string &prefix );
     
     string rid; //recording id
 

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -509,7 +509,7 @@ protected:
     \brief Write recorded data and metadata in NIX format.
   */
   struct NixFile {
-    const double   relacs_nix_version = 1.0;
+    const double   relacs_nix_version = 1.1;
     double         repro_start_time = 0.0;
     double         stimulus_start_time = 0.0;
     double         stimulus_duration = 0.0;

--- a/relacs/include/relacs/savefiles.h
+++ b/relacs/include/relacs/savefiles.h
@@ -529,10 +529,9 @@ protected:
     void close ( void );
     void saveMetadata ( const AllDevices *devices );
     void saveMetadata ( const MetaData &mtdt );
-    void createStimulusTag ( const std::string &repro_name, const Options &stimulus_options,
-                             const Options &stimulus_features, const deque< OutDataInfo > &stim_info,
-                             const Acquire *AQ, double start_time, double duration,
-			     NixStimulusInfo &info );
+    void createStimulusTag ( const std::string &repro_name, const Options &stimulus_features,
+			     const deque< OutDataInfo > &stim_info, const Acquire *AQ,
+			     double start_time, double duration, NixStimulusInfo &info );
     void writeStimulus( const InList &IL, const EventList &EL,
 			const deque< OutDataInfo > &stimuliinfo,
 			const deque< bool > &newstimuli, const Options &data,

--- a/relacs/src/filterselector.cc
+++ b/relacs/src/filterselector.cc
@@ -50,7 +50,7 @@ Options initTemplate()
   opt.addText("panel");
   opt.addInteger("linewidth");
 
-  return std::move(opt);
+  return opt;
 }
 
 static const Options OPTION_TEMPLATE = initTemplate();

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -2196,11 +2196,14 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const
 					"", "id", nix::LinkType::Indexed, nix::DataType::String );
   // stimulus_features
   if ( !stimulus_features.empty() ) {
-    createFeaturesForOptions( stimulus_features, "relacs_feature" );
+    createFeaturesForOptions( stimulus_features, "relacs_feature", "" );
   }
 
   // additional stim_options
   createFeaturesForOptions( stim_options, "relacs.feature.mutable" );
+    // additional stim_options
+    createFeaturesForOptions( stim_info[i].description(), "relacs.feature.mutable", channel_prefix );
+  }
 }
 
 
@@ -2307,14 +2310,14 @@ nix::DataArray SaveFiles::NixFile::createFeature( nix::MultiTag &mtag,
 }
 
 
-void SaveFiles::NixFile::createFeaturesForOptions( const Options &options, std::string type)
+void SaveFiles::NixFile::createFeaturesForOptions( const Options &options, const std::string &type, const std::string &name_prefix )
 {
   std::string name;
   std::string unit;
   std::string label;
   for ( Parameter p : options ) {
     if ( (p.flags() & OutData::Mutable ) > 0) {
-      name =  current_stimulus_info.name + "_" + p.name();
+      name =  name_prefix + "_" + current_stimulus_info.name + "_" + p.name();
       unit = p.unit();
       nix::util::unitSanitizer( unit );
       label = p.name();

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -2254,6 +2254,7 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
                     const deque< Options > &stimuliref, int *stimulusindex,
                     double sessiontime, const string &reproname, const Acquire *acquire )
 {
+  if ( !fd || IL[0].signalIndex() < 1 || stim_info.size() == 0)
     return;
 
   double abs_time = IL[0].signalTime() - sessiontime;
@@ -2266,8 +2267,7 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
   stimulus_duration = stim_info[0].length() - stepsize;
   
   if ( current_stimulus_info.name != tag_name ) { // previous stimulus does not match the current
-    std::map<std::string, NixStimulusInfo>::iterator it;
-    it = stim_info_buffer.find( tag_name );
+    std::map<std::string, NixStimulusInfo>::iterator it = stim_info_buffer.find( tag_name );
     if ( it != stim_info_buffer.end() ) { // we have one in store, take it
       current_stimulus_info = it->second;
     } else { // no match and not found, create a new one
@@ -2282,16 +2282,17 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
     appendValue( current_stimulus_info.positions_array, stimulus_start_time );
     appendValue( current_stimulus_info.extents_array, stimulus_duration );
   }
+  std::cerr << "store features\n";
 
   // handle options that are stored as features
   storeOptionsToFeatures( stim_options );
   Options mutables = stimuliref[0].section( "parameter" );
-  storeOptionsToFeatures( mutables );
+  //  storeOptionsToFeatures( mutables ); FIXME
 
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_repro_tag_id" ), repro_tag_id );
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_abs_time" ), abs_time );
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_delay" ), delay );
-  appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_amplitude" ), intensity );
+  //appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_amplitude" ), intensity ); FIXME is per channel
   fd.flush();
 }
 

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -2189,6 +2189,7 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &tag_name, const O
     createFeaturesForOptions( stimulus_features, "relacs_feature", "" );
   }
 
+  std::string name_prefix = "Output";
   for ( size_t i = 0; i < stim_info.size(); ++i ) {
     std::string channel_prefix = name_prefix + Str(stim_info[i].channel());
 
@@ -2280,17 +2281,21 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
     appendValue( current_stimulus_info.positions_array, stimulus_start_time );
     appendValue( current_stimulus_info.extents_array, stimulus_duration );
   }
-  std::cerr << "store features\n";
 
   // handle options that are stored as features
-  storeOptionsToFeatures( stim_options );
-  Options mutables = stimuliref[0].section( "parameter" );
-  //  storeOptionsToFeatures( mutables ); FIXME
+  storeOptionsToFeatures( stim_options, "" );
+
+  for (size_t i =0; i < stimuliref.size(); ++i) {
+      Options mutables = stimuliref[i].section( "parameter" );
+      string prefix = stimuliref.size() == 1 ? "" : "Output" + Str(stim_info[i].channel());
+      storeOptionsToFeatures( mutables , prefix);
+      appendValue( current_stimulus_info.features.at( prefix + "_" + current_stimulus_info.name + "_amplitude" ),
+		   intensity );
+  }
 
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_repro_tag_id" ), repro_tag_id );
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_abs_time" ), abs_time );
   appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_delay" ), delay );
-  //appendValue( current_stimulus_info.features.at( current_stimulus_info.name + "_amplitude" ), intensity ); FIXME is per channel
   fd.flush();
 }
 

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -1986,6 +1986,7 @@ void SaveFiles::NixFile::saveMetadata (const AllDevices *devices)
     while (sec_name.find("/") != sec_name.npos) {
       sec_name.replace(sec_name.find("/"), 1, "_");
     }
+    
     nix::Section s = hw.createSection(sec_name, dts);
     Options opts( dev.info() );
     opts.erase( "type" );
@@ -2013,7 +2014,6 @@ void SaveFiles::NixFile::writeRePro ( const Options &reproinfo, const deque< str
   if ( !fd || traces.size() < 1 ) {
     return;
   }
-
   nix::Section s = fd.createSection( repro_name, "relacs.repro" );
   saveNIXOptions( reproinfo, s, Options::FirstOnly, 0 );
   if ( reprofiles.size() > 0 ) {
@@ -2189,8 +2189,6 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &tag_name, const O
     createFeaturesForOptions( stimulus_features, "relacs_feature", "" );
   }
 
-  std::cerr << "createStimTag\n";
-  std::string name_prefix = "Channel";
   for ( size_t i = 0; i < stim_info.size(); ++i ) {
     std::string channel_prefix = name_prefix + Str(stim_info[i].channel());
 
@@ -2342,12 +2340,12 @@ void SaveFiles::NixFile::createFeaturesForOptions( const Options &options, const
 }
 
 
-void SaveFiles::NixFile::storeOptionsToFeatures( const Options &options )
+void SaveFiles::NixFile::storeOptionsToFeatures( const Options &options , const std::string &prefix )
 {
   std::string prop_name;
   std::map<std::string, nix::DataArray>::iterator it;
   for ( auto p : options ) {
-    prop_name = current_stimulus_info.name + "_" + p.name();
+    prop_name = prefix + "_" + current_stimulus_info.name + "_" + p.name();
     it = current_stimulus_info.features.find( prop_name );
     if ( it != current_stimulus_info.features.end() ) {
       if ( p.isNumber() ) {

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -2237,12 +2237,18 @@ string createStimulusTagName( const deque< OutDataInfo > &stim_info ) {
     else
       break;
   }
+  std::vector<std::string> ugly_endings = {"-", "_", "/", ".", ":"};
+  for ( auto end : ugly_endings ) {
+    if ( prefix.rfind( end ) == prefix.size() - 1 && prefix.size() -2 > 0 )
+      prefix = prefix.substr(0, prefix.size() - 1);
+  }
 
   string suffix = "";
   size_t lastpos = std::string::npos;
   lastpos = stim_info[0].description().name().rfind( "-" );
   if ( lastpos != std::string::npos )
     suffix = stim_info[0].description().name().substr(lastpos);
+      
   string tagname = prefix + suffix;
   return nix::util::nameSanitizer( tagname );
 }

--- a/relacs/src/savefiles.cc
+++ b/relacs/src/savefiles.cc
@@ -2204,6 +2204,41 @@ void SaveFiles::NixFile::createStimulusTag( const std::string &repro_name, const
 }
 
 
+string createStimulusTagName( const deque< OutDataInfo > &stim_info ) {
+  if ( stim_info.size() == 1 ) {
+    return nix::util::nameSanitizer(stim_info[0].description().name());
+  }
+  
+  size_t min_length = 9999999;
+  for (size_t i = 0; i < stim_info.size(); ++i) {
+    min_length = (stim_info[i].description().name().size() < min_length) ? stim_info[i].description().name().size() : min_length;
+  }
+  string prefix = "";
+  for ( size_t i = 0; i < min_length; ++i ) {
+    string s = stim_info[0].description().name().substr(i,1);
+    bool match = true;
+    for (size_t j = 1; j < stim_info.size(); ++j ) {
+      string cmp = stim_info[j].description().name().substr(i, 1); 
+      if ( cmp != s ) {
+	match = false;
+	break;
+      }
+    }
+    if ( match )
+      prefix += s;
+    else
+      break;
+  }
+
+  string suffix = "";
+  size_t lastpos = std::string::npos;
+  lastpos = stim_info[0].description().name().rfind( "-" );
+  if ( lastpos != std::string::npos )
+    suffix = stim_info[0].description().name().substr(lastpos);
+  string tagname = prefix + suffix;
+  return nix::util::nameSanitizer( tagname );
+}
+
 void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
                     const deque< OutDataInfo > &stim_info,
                     const deque< bool > &newstimuli, const Options &stim_options,
@@ -2218,7 +2253,7 @@ void SaveFiles::NixFile::writeStimulus( const InList &IL, const EventList &EL,
   double intensity = stim_info[0].intensity();
   bool new_stim = false;
   NixTrace trace = traces[0];
-  string tag_name = nix::util::nameSanitizer(stim_info[0].description().name());
+  string tag_name = createStimulusTagName( stim_info );
   stimulus_start_time = (IL[0].signalIndex() - trace.index  + trace.written) * stepsize;
   stimulus_duration = stim_info[0].length() - stepsize;
   


### PR DESCRIPTION
If there is more than one output channel the stimulus tag metadata now contains the same number of subsections. Mutable options are prefixed with "OutputN" withN being the output signal number.